### PR TITLE
Expose the creation of Reader/Writer

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -16,14 +16,15 @@
 
 package com.github.tototoshi.csv
 
-import au.com.bytecode.opencsv.{ CSVReader => JCSVReader }
+import au.com.bytecode.opencsv.{CSVReader => JCSVReader, CSVParser}
 import java.io._
 import scala.collection.JavaConversions._
 import java.util.NoSuchElementException
+import au.com.bytecode.opencsv
 
-class CSVReader protected (reader: Reader) {
+class CSVReader protected (reader: => JCSVReader) {
 
-  private val underlying: JCSVReader = new JCSVReader(reader)
+  private val underlying: JCSVReader = reader
 
   def apply[A](f: Iterator[Seq[String]] => A): A = {
     try {
@@ -86,7 +87,9 @@ object CSVReader {
   @deprecated("Use #open instead", "0.5.0")
   def apply(reader: Reader): CSVReader = open(reader)
 
-  def open(reader: Reader): CSVReader = new CSVReader(reader)
+  def open(reader: => JCSVReader) = new CSVReader(reader)
+
+  def open(reader: Reader): CSVReader = new CSVReader(new opencsv.CSVReader(reader))
 
   def open(file: File): CSVReader = open(file, "UTF-8")
 

--- a/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
@@ -19,10 +19,11 @@ package com.github.tototoshi.csv
 import scala.collection.JavaConversions._
 import au.com.bytecode.opencsv.{ CSVWriter => JCSVWriter }
 import java.io.{ File, Writer, FileOutputStream, OutputStreamWriter }
+import au.com.bytecode.opencsv
 
-class CSVWriter protected (writer: Writer) {
+class CSVWriter protected (writer: => JCSVWriter) {
 
-  private val underlying: JCSVWriter = new JCSVWriter(writer)
+  private val underlying: JCSVWriter = writer
 
   def apply[A](f: CSVWriter => A): A = {
     try {
@@ -59,7 +60,9 @@ object CSVWriter {
   @deprecated("Use #open instead", "0.5.0")
   def apply(writer: Writer): CSVWriter = open(writer)
 
-  def open(writer: Writer): CSVWriter = new CSVWriter(writer)
+  def open(writer: => JCSVWriter) = new CSVWriter(writer)
+
+  def open(writer: Writer): CSVWriter = new CSVWriter(new JCSVWriter(writer))
 
   def open(file: File): CSVWriter = open(file, false, "UTF-8")
 


### PR DESCRIPTION
A quick and dirty hack to expose OpenCSV.

My need was to customize the creation of the OpenCSV writer/reader (different quote character, etc).

The proper solution would probably be to introduce some kind of CsvConfig/CsvSpec object that describes the format of the Csv we want to parse, but in the meanwhile, this hack does the work...

Pull-requesting in case you're interested in it. If not, you can just ignore it.
