### PR TITLE
Fixed resource leaks when an invalid encoding was passed

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -124,8 +124,12 @@ object CSVReader {
 
   def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader = {
     val fin = new FileInputStream(file)
-    val reader = new InputStreamReader(fin, encoding)
-    open(reader)(format)
+    try {
+      val reader = new InputStreamReader(fin, encoding)
+      open(reader)(format)
+    } catch {
+      case e: UnsupportedEncodingException => fin.close(); throw e
+    }
   }
 
   def open(filename: String)(implicit format: CSVFormat) : CSVReader =

--- a/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
@@ -118,8 +118,12 @@ object CSVWriter {
 
   def open(file: File, append: Boolean, encoding: String)(implicit format: CSVFormat): CSVWriter = {
     val fos = new FileOutputStream(file, append)
-    val writer = new OutputStreamWriter(fos, encoding)
-    open(writer)(format)
+    try {
+      val writer = new OutputStreamWriter(fos, encoding)
+      open(writer)(format)
+    } catch {
+      case e: UnsupportedEncodingException => fos.close(); throw e
+    }
   }
 
   def open(file: String)(implicit format: CSVFormat): CSVWriter = open(file, false, "UTF-8")(format)


### PR DESCRIPTION
When an invalid encoding string was passed, fin and fos could not close.
