### PR TITLE
update Scala version, remove scala-parser-combinators dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-  - "2.11.0"
-  - "2.10.0"
+  - "2.11.4"
+  - "2.10.4"
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,16 +11,12 @@ object ScalaCSVProject extends Build {
       name := "scala-csv",
       version := "1.1.0",
       scalaVersion := "2.11.4",
-      crossScalaVersions := Seq("2.11.4", "2.10.3"),
+      crossScalaVersions := Seq("2.11.4", "2.10.4"),
       organization := "com.github.tototoshi",
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "2.1.3" % "test",
         "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
       ),
-      libraryDependencies ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
-        case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-          "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
-      }.toList,
       scalacOptions ++= Seq(
         "-deprecation",
         "-language:_"

--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -18,7 +18,6 @@ package com.github.tototoshi.csv
 
 import java.io._
 import java.util.NoSuchElementException
-import scala.util.parsing.input.CharSequenceReader
 
 class CSVReader protected (private val reader: Reader)(implicit format: CSVFormat) extends Closeable {
 


### PR DESCRIPTION
Scala2.10.0 does not work with Java8. we should update Scala version

https://travis-ci.org/tototoshi/scala-csv/jobs/40079622#L221

```
[info] 'compiler-interface' not yet compiled for Scala 2.10.0. Compiling...
error: error while loading CharSequence, class file '/usr/lib/jvm/java-8-oracle/jre/lib/rt.jar(java/lang/CharSequence.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 10)
error: error while loading Comparator, class file '/usr/lib/jvm/java-8-oracle/jre/lib/rt.jar(java/util/Comparator.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 20)
error: error while loading AnnotatedElement, class file '/usr/lib/jvm/java-8-oracle/jre/lib/rt.jar(java/lang/reflect/AnnotatedElement.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 76)
error: error while loading Arrays, class file '/usr/lib/jvm/java-8-oracle/jre/lib/rt.jar(java/util/Arrays.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 765)
/tmp/sbt_9b5b5377/xsbt/ExtractAPI.scala:395: error: java.util.Comparator does not take type parameters
    private[this] val sortClasses = new Comparator[Symbol] {
                                            ^
5 errors found
[error] (compile:compile) Error compiling sbt component 'compiler-interface'
```
