### PR TITLE
Returning header names in the correct order along with data.

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -88,10 +88,16 @@ class CSVReader protected (private val reader: Reader)(implicit format: CSVForma
   }
 
   def allWithHeaders(): List[Map[String, String]] = {
-    readNext() map { headers =>
+    allWithOrderedHeaders._2
+  }
+
+  def allWithOrderedHeaders(): (List[String], List[Map[String, String]]) = {
+    val headers = readNext()
+    val data = headers.map(headers => {
       val lines = all()
       lines.map(l => headers.zip(l).toMap)
-    } getOrElse List()
+    })
+    (headers.getOrElse(Nil), data.getOrElse(Nil))
   }
 
   def close(): Unit = {

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -274,5 +274,30 @@ class CSVReaderSpec extends FunSpec with ShouldMatchers with Using {
       }
     }
 
+    describe("#allOrderedHeaders") {
+      describe("When the file is empty") {
+        it("returns an empty list") {
+          using(CSVReader.open(new FileReader("src/test/resources/empty.csv"))) { reader =>
+            reader.allWithOrderedHeaders() should be((Nil, Nil))
+          }
+        }
+      }
+      describe("When the file has only header line") {
+        it("returns only header names") {
+          using(CSVReader.open(new FileReader("src/test/resources/only-header.csv"))) { reader =>
+            reader.allWithOrderedHeaders should be((List("foo", "bar"), Nil))
+          }
+        }
+      }
+      describe("When the file has many headers and many lines") {
+        it("returns header names in order and data") {
+          using(CSVReader.open(new FileReader("src/test/resources/with-headers.csv"))) { reader =>
+            val result = reader.allWithOrderedHeaders()
+            result._1 should be(List("Foo", "Bar", "Baz"))
+            result._2 should be(List(Map("Foo" -> "a", "Bar" -> "b", "Baz" -> "c"), Map("Foo" -> "d", "Bar" -> "e", "Baz" -> "f")))
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
I have the requirement to be able to rebuild the CSV data on the client in exactly the same format as was sent from the server. The "allWithHeaders" method worked well for me but as a map doesn't keep the order, I wasn't able to rebuild the columns in the correct order.

I added a additional method "allWithOrderedHeaders" which returns a tuple (List[String], List[Map[String, String]]) allowing me to iterate through the headers in the same order as they are defined in the CSV data.
