### PR TITLE
Type-class based serialization into CSV.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,6 +14,7 @@ object ScalaCSVProject extends Build {
       crossScalaVersions := Seq("2.11.6", "2.10.4"),
       organization := "com.github.tototoshi",
       libraryDependencies ++= Seq(
+        "com.chuusai" % "shapeless_2.11" % "2.2.0",
         "org.scalatest" %% "scalatest" % "2.1.3" % "test",
         "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
       ),

--- a/src/main/scala/com/github/tototoshi/csv/typed/AsCsv.scala
+++ b/src/main/scala/com/github/tototoshi/csv/typed/AsCsv.scala
@@ -1,0 +1,13 @@
+package com.github.tototoshi.csv.typed
+
+import shapeless.{ Sized, Nat }
+
+trait AsCsv[Whole] {
+  type HeaderSize <: Nat
+  def header: Sized[Seq[String], HeaderSize]
+
+  type Record
+  def asCsvRecord: AsCsvRecord[Record] { type RecordSize = HeaderSize }
+
+  def records(whole: Whole): Seq[Record]
+}

--- a/src/main/scala/com/github/tototoshi/csv/typed/AsCsvRecord.scala
+++ b/src/main/scala/com/github/tototoshi/csv/typed/AsCsvRecord.scala
@@ -1,0 +1,13 @@
+package com.github.tototoshi.csv.typed
+
+import shapeless.Nat
+import shapeless.Sized
+
+trait AsCsvRecord[Record] {
+  type RecordSize <: Nat
+  def fields(record: Record): Sized[Seq[String], RecordSize]
+}
+
+object AsCsvRecord {
+  type Aux[Record, N <: Nat] = AsCsvRecord[Record] { type RecordSize = N }
+}

--- a/src/main/scala/com/github/tototoshi/csv/typed/package.scala
+++ b/src/main/scala/com/github/tototoshi/csv/typed/package.scala
@@ -1,0 +1,16 @@
+package com.github.tototoshi.csv
+
+import java.io.Writer
+
+package object typed {
+
+  implicit class AsCsvOps[Whole](val whole: Whole)(implicit wholeAsCsv: AsCsv[Whole]) {
+    def asCsvInto(writer: Writer): Unit = {
+      val csvWriter = CSVWriter.open(writer)
+      csvWriter.writeRow(wholeAsCsv.header)
+      for (record <- wholeAsCsv.records(whole)) {
+        csvWriter.writeRow(wholeAsCsv.asCsvRecord.fields(record))
+      }
+    }
+  }
+}

--- a/src/test/scala/com/github/tototoshi/csv/typed/AsCsvSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/typed/AsCsvSpec.scala
@@ -1,0 +1,56 @@
+package com.github.tototoshi.csv.typed
+
+import java.io.StringWriter
+
+import com.github.tototoshi.csv.Using
+import org.scalatest._
+import shapeless.Sized
+import shapeless.Nat._2
+
+class AsCsvSpec extends FunSpec with ShouldMatchers with Using {
+  case class Report(name: String, entries: Seq[Entry])
+
+  case class Entry(someField: String, someOtherField: Int)
+
+  object Report {
+    implicit val reportAsCsv: AsCsv[Report] = new AsCsv[Report] {
+      type HeaderSize = _2
+      def header: Sized[Seq[String], HeaderSize] = {
+        Sized("somefield", "someotherfield")
+      }
+
+      type Record = Entry
+      lazy val asCsvRecord = implicitly[AsCsvRecord[Record] { type RecordSize = HeaderSize }]
+
+      def records(report: Report): Seq[Record] = report.entries
+    }
+  }
+
+  object Entry {
+    implicit val entryAsCsvRecord: AsCsvRecord.Aux[Entry, _2] = new AsCsvRecord[Entry] {
+      type RecordSize = _2
+
+      def fields(entry: Entry): Sized[Seq[String], RecordSize] = {
+        Sized(entry.someField, entry.someOtherField.toString)
+      }
+    }
+  }
+
+  describe("AsCsv") {
+    it("should serialize values to CSV as dictated in their type class instances") {
+      val report = Report("irrelevant", Seq(
+        Entry("jan", 104),
+        Entry("feb", 98),
+        Entry("mar", 110)
+      ))
+
+      val stringWriter = new StringWriter
+      report.asCsvInto(stringWriter)
+      stringWriter.close()
+
+      println(stringWriter.toString)
+
+      stringWriter.toString should equal("somefield,someotherfield\r\njan,104\r\nfeb,98\r\nmar,110\r\n")
+    }
+  }
+}


### PR DESCRIPTION
This PR adds two type-classes, namely `AsCsv` and `AsCsvRecord`. 
* If you have an instance of `AsCsv[A]`, the whole data structure of type `A` can be written to a CSV file. 
* If you have an instance of `AsCsvRecord[E]`, an entry of type `E` can be written to a CSV file.
* The `AsCsv` instance `AsCsvRecord` instance must agree on the size of headers and records. **This is enforced at the compile time.**

This is useful since one might want to separate out CSV protocols from the actual domain logic, and type-classes are a canonical way to do that.