### PR TITLE
Add ability to use scala.io.Source as a source for CSV Reader

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object ScalaCSVProject extends Build {
     base = file ("."),
     settings = Defaults.defaultSettings ++ Seq (
       name := "scala-csv",
-      version := "1.2.2",
+      version := "1.2.3-SNAPSHOT",
       scalaVersion := "2.11.6",
       crossScalaVersions := Seq("2.11.6", "2.10.4"),
       organization := "com.github.tototoshi",

--- a/src/main/java/com/github/tototoshi/csv/FileLineReader.java
+++ b/src/main/java/com/github/tototoshi/csv/FileLineReader.java
@@ -1,0 +1,63 @@
+package com.github.tototoshi.csv;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+
+public class FileLineReader implements LineReader {
+
+    private BufferedReader bufferedReader;
+
+    public FileLineReader(Reader reader) {
+        this.bufferedReader = new BufferedReader(reader);
+    }
+
+    public String readLineWithTerminator() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        do {
+
+            int c = bufferedReader.read();
+
+            if (c == -1) {
+                if (sb.length() == 0) {
+                    return null;
+                } else {
+                    break;
+                }
+            }
+
+            sb.append((char) c);
+
+            if (c == '\n'
+                    || c == '\u2028'
+                    || c == '\u2029'
+                    || c == '\u0085') {
+                break;
+            }
+
+            if (c == '\r') {
+
+                bufferedReader.mark(1);
+
+                c = bufferedReader.read();
+
+                if (c == -1) {
+                    break;
+                } else if (c == '\n') {
+                    sb.append('\n');
+                } else {
+                    bufferedReader.reset();
+                }
+
+                break;
+            }
+
+        } while (true);
+
+        return sb.toString();
+    }
+
+    public void close() throws IOException {
+        bufferedReader.close();
+    }
+}

--- a/src/main/java/com/github/tototoshi/csv/LineReader.java
+++ b/src/main/java/com/github/tototoshi/csv/LineReader.java
@@ -1,64 +1,10 @@
 package com.github.tototoshi.csv;
 
-import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.Reader;
 
-public class LineReader {
+public interface LineReader extends Closeable {
 
-    private BufferedReader bufferedReader;
-
-    public LineReader(Reader reader) {
-        this.bufferedReader = new BufferedReader(reader);
-    }
-
-    public String readLineWithTerminator() throws IOException {
-        int c = -1;
-        StringBuilder sb = new StringBuilder();
-        do {
-
-            c = bufferedReader.read();
-
-            if (c == -1) {
-                if (sb.length() == 0) {
-                    return null;
-                } else {
-                    break;
-                }
-            }
-
-            sb.append((char) c);
-
-            if (c == '\n'
-                || c == '\u2028'
-                || c == '\u2029'
-                || c == '\u0085') {
-                break;
-            }
-
-            if (c == '\r') {
-
-                bufferedReader.mark(1);
-
-                c = bufferedReader.read();
-
-                if (c == -1) {
-                    break;
-                } else if (c == '\n') {
-                    sb.append('\n');
-                } else {
-                    bufferedReader.reset();
-                }
-
-                break;
-            }
-
-        } while (true);
-
-        return sb.toString();
-    }
-
-    public void close() throws IOException {
-        bufferedReader.close();
-    }
+    String readLineWithTerminator() throws IOException;
 }
+

--- a/src/main/java/com/github/tototoshi/csv/ReaderLineReader.java
+++ b/src/main/java/com/github/tototoshi/csv/ReaderLineReader.java
@@ -7,8 +7,10 @@ import java.io.Reader;
 public class ReaderLineReader implements LineReader {
 
     private BufferedReader bufferedReader;
+    private Reader baseReader;
 
     public ReaderLineReader(Reader reader) {
+        this.baseReader = reader;
         this.bufferedReader = new BufferedReader(reader);
     }
 
@@ -59,5 +61,6 @@ public class ReaderLineReader implements LineReader {
 
     public void close() throws IOException {
         bufferedReader.close();
+        baseReader.close();
     }
 }

--- a/src/main/java/com/github/tototoshi/csv/ReaderLineReader.java
+++ b/src/main/java/com/github/tototoshi/csv/ReaderLineReader.java
@@ -4,11 +4,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
-public class FileLineReader implements LineReader {
+public class ReaderLineReader implements LineReader {
 
     private BufferedReader bufferedReader;
 
-    public FileLineReader(Reader reader) {
+    public ReaderLineReader(Reader reader) {
         this.bufferedReader = new BufferedReader(reader);
     }
 

--- a/src/main/java/com/github/tototoshi/csv/SourceLineReader.java
+++ b/src/main/java/com/github/tototoshi/csv/SourceLineReader.java
@@ -6,24 +6,24 @@ import java.io.IOException;
 
 public class SourceLineReader implements LineReader {
 
-    private Source reader;
+    private Source source;
 
-    public SourceLineReader(Source reader) {
-        this.reader = reader;
+    public SourceLineReader(Source source) {
+        this.source = source;
     }
 
     @Override
     public String readLineWithTerminator() throws IOException {
         StringBuilder sb = new StringBuilder();
         while(true) {
-            if (!reader.hasNext()) {
+            if (!source.hasNext()) {
                 if (sb.length() == 0) {
                     return null;
                 } else {
                     break;
                 }
             }
-            int c = reader.next();
+            int c = source.next();
 
             sb.append((char) c);
 
@@ -35,10 +35,10 @@ public class SourceLineReader implements LineReader {
             }
 
             if (c == '\r') {
-                if (!reader.hasNext()) {
+                if (!source.hasNext()) {
                     break;
                 }
-                c = reader.next();
+                c = source.next();
                 sb.append(c);
                 if (c == '\n') {
                     break;
@@ -50,6 +50,6 @@ public class SourceLineReader implements LineReader {
 
     @Override
     public void close() throws IOException {
-        reader.close();
+        source.close();
     }
 }

--- a/src/main/java/com/github/tototoshi/csv/SourceLineReader.java
+++ b/src/main/java/com/github/tototoshi/csv/SourceLineReader.java
@@ -1,0 +1,55 @@
+package com.github.tototoshi.csv;
+
+import scala.io.Source;
+
+import java.io.IOException;
+
+public class SourceLineReader implements LineReader {
+
+    private Source reader;
+
+    public SourceLineReader(Source reader) {
+        this.reader = reader;
+    }
+
+    @Override
+    public String readLineWithTerminator() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        while(true) {
+            if (!reader.hasNext()) {
+                if (sb.length() == 0) {
+                    return null;
+                } else {
+                    break;
+                }
+            }
+            int c = reader.next();
+
+            sb.append((char) c);
+
+            if (c == '\n'
+                    || c == '\u2028'
+                    || c == '\u2029'
+                    || c == '\u0085') {
+                break;
+            }
+
+            if (c == '\r') {
+                if (!reader.hasNext()) {
+                    break;
+                }
+                c = reader.next();
+                sb.append(c);
+                if (c == '\n') {
+                    break;
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+}

--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -94,7 +94,7 @@ class CSVReader protected (private val lineReader: LineReader)(implicit format: 
   }
 
   def allWithHeaders(): List[Map[String, String]] = {
-    allWithOrderedHeaders()._2
+    allWithOrderedHeaders._2
   }
 
   def allWithOrderedHeaders(): (List[String], List[Map[String, String]]) = {
@@ -126,7 +126,7 @@ object CSVReader {
   def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader = {
     val fin = new FileInputStream(file)
     try {
-      open(Source.fromInputStream(fin, encoding))
+      open(new InputStreamReader(fin, encoding))(format)
     } catch {
       case e: UnsupportedEncodingException => fin.close(); throw e
     }

--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -117,7 +117,7 @@ object CSVReader {
 
   def open(source: Source)(implicit format: CSVFormat): CSVReader = new CSVReader(new SourceLineReader(source))(format)
 
-  def open(reader: Reader)(implicit format: CSVFormat): CSVReader = new CSVReader(new FileLineReader(reader))(format)
+  def open(reader: Reader)(implicit format: CSVFormat): CSVReader = new CSVReader(new ReaderLineReader(reader))(format)
 
   def open(file: File)(implicit format: CSVFormat): CSVReader = {
     open(file, this.DEFAULT_ENCODING)(format)

--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -84,7 +84,7 @@ class CSVReader protected (private val lineReader: LineReader)(implicit format: 
     }).getOrElse(Iterator())
   }
 
-  def toStreamWithHeaders: Stream[Map[String,String]] = iteratorWithHeaders.toStream
+  def toStreamWithHeaders: Stream[Map[String, String]] = iteratorWithHeaders.toStream
 
   def toStream: Stream[List[String]] =
     Stream.continually(readNext()).takeWhile(_.isDefined).map(_.get)
@@ -115,9 +115,9 @@ object CSVReader {
 
   val DEFAULT_ENCODING = "UTF-8"
 
-  def open(source: Source)(implicit format: CSVFormat): CSVReader = new CSVReader(new SourceLineReader(source))
+  def open(source: Source)(implicit format: CSVFormat): CSVReader = new CSVReader(new SourceLineReader(source))(format)
 
-  def open(reader: Reader)(implicit format: CSVFormat): CSVReader = new CSVReader(new FileLineReader(reader))
+  def open(reader: Reader)(implicit format: CSVFormat): CSVReader = new CSVReader(new FileLineReader(reader))(format)
 
   def open(file: File)(implicit format: CSVFormat): CSVReader = {
     open(file, this.DEFAULT_ENCODING)(format)
@@ -126,7 +126,7 @@ object CSVReader {
   def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader = {
     val fin = new FileInputStream(file)
     try {
-      open(Source.fromInputStream(fin,encoding))
+      open(Source.fromInputStream(fin, encoding))
     } catch {
       case e: UnsupportedEncodingException => fin.close(); throw e
     }

--- a/src/test/scala/com/github/tototoshi/csv/LineReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/LineReaderSpec.scala
@@ -1,16 +1,32 @@
 package com.github.tototoshi.csv
 
-import java.io.{ UnsupportedEncodingException, FileReader, File, StringReader }
+import java.io.FileReader
 
 import org.scalatest._
 
+import scala.io.Source
+
 class LineReaderSpec extends FunSpec with ShouldMatchers with Using {
 
-  describe("LineReader") {
+  describe("ReaderLineReader") {
 
     it("should read line with nl") {
       using(new FileReader("src/test/resources/has-empty-line.csv")) { in =>
-        using(new FileLineReader(in)) { reader =>
+        using(new ReaderLineReader(in)) { reader =>
+          reader.readLineWithTerminator() should be("a,b,c\n")
+          reader.readLineWithTerminator() should be("\n")
+          reader.readLineWithTerminator() should be("d,e,f")
+        }
+      }
+    }
+
+  }
+
+  describe("SourceLineReader") {
+
+    it("should read line with nl") {
+      using(Source.fromFile("src/test/resources/has-empty-line.csv")) { in =>
+        using(new SourceLineReader(in)) { reader =>
           reader.readLineWithTerminator() should be("a,b,c\n")
           reader.readLineWithTerminator() should be("\n")
           reader.readLineWithTerminator() should be("d,e,f")

--- a/src/test/scala/com/github/tototoshi/csv/LineReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/LineReaderSpec.scala
@@ -10,7 +10,7 @@ class LineReaderSpec extends FunSpec with ShouldMatchers with Using {
 
     it("should read line with nl") {
       using(new FileReader("src/test/resources/has-empty-line.csv")) { in =>
-        using(new LineReader(in)) { reader =>
+        using(new FileLineReader(in)) { reader =>
           reader.readLineWithTerminator() should be("a,b,c\n")
           reader.readLineWithTerminator() should be("\n")
           reader.readLineWithTerminator() should be("d,e,f")


### PR DESCRIPTION
I have refactored the LineReader and CSVReader companion object's open methods to add the ability to use a scala.io.Source to read a CSV data source.