### PR TITLE
Use system line endings for default formats

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/Formats.scala
+++ b/src/main/scala/com/github/tototoshi/csv/Formats.scala
@@ -23,7 +23,7 @@ trait DefaultCSVFormat extends CSVFormat {
 
   val escapeChar: Char = '"'
 
-  val lineTerminator: String = "\r\n"
+  val lineTerminator: String = System.lineSeparator
 
   val quoting: Quoting = QUOTE_MINIMAL
 
@@ -39,7 +39,7 @@ trait TSVFormat extends CSVFormat {
 
   val escapeChar: Char = '\\'
 
-  val lineTerminator: String = "\r\n"
+  val lineTerminator: String = System.lineSeparator
 
   val quoting: Quoting = QUOTE_NONE
 


### PR DESCRIPTION
My tests were failing due to mismatched line endings.
I though it would make more sense to use the system line endings by default.
Didn't break any tests.