### PR TITLE
Hide implicit CSVFormat in dedicated object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ libraryDependencies += "com.github.tototoshi" %% "scala-csv" % "1.3.0-SNAPSHOT"
 
 ```scala
 scala> import com.github.tototoshi.csv._
+scala> import implicits._ // for a default CSVFormat instance
 ```
 
 ### Reading example

--- a/src/main/scala/com/github/tototoshi/csv/CSVFormat.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVFormat.scala
@@ -15,6 +15,11 @@
 */
 package com.github.tototoshi.csv
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "Cannot find implicit instance of com.github.tototoshi.csv.CSVFormat. Create your own, or import com.github.tototoshi.csv.implicits._"
+)
 trait CSVFormat {
 
   val delimiter: Char

--- a/src/main/scala/com/github/tototoshi/csv/package.scala
+++ b/src/main/scala/com/github/tototoshi/csv/package.scala
@@ -18,6 +18,8 @@ package com.github.tototoshi
 
 package object csv {
 
-  implicit val defaultCSVFormat = new DefaultCSVFormat {}
+  object implicits {
+    implicit val defaultCSVFormat: CSVFormat = new DefaultCSVFormat {}
+  }
 
 }

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -3,6 +3,7 @@ package com.github.tototoshi.csv
 import java.io.{ UnsupportedEncodingException, FileReader, File, StringReader }
 
 import org.scalatest._
+import implicits._
 
 class CSVReaderSpec extends FunSpec with ShouldMatchers with Using {
 

--- a/src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala
@@ -3,6 +3,7 @@ package com.github.tototoshi.csv
 import java.io.{ FileOutputStream, UnsupportedEncodingException, FileWriter, File }
 
 import org.scalatest._
+import implicits._
 
 class CSVWriterSpec extends FunSpec with ShouldMatchers with BeforeAndAfter with Using {
 


### PR DESCRIPTION
This avoids ambigous implicit instances