### PR TITLE
Added CSV Writer Benchmarks

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,8 @@ object ScalaCSVProject extends Build {
       organization := "com.github.tototoshi",
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-        "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
+        "org.scalacheck" %% "scalacheck" % "1.11.4" % "test",
+        "com.storm-enroute" %% "scalameter" % "0.7"
       ),
       scalacOptions ++= Seq(
         "-deprecation",
@@ -24,6 +25,11 @@ object ScalaCSVProject extends Build {
         if(scalaVersion.value.startsWith("2.11")) Seq("-Ywarn-unused")
         else Nil
       },
+      testFrameworks += new TestFramework(
+        "org.scalameter.ScalaMeterFramework"
+      ),
+      parallelExecution in Test := false,
+      logBuffered := false,
       javacOptions in compile ++= Seq("-target", "6", "-source", "6", "-Xlint"),
       initialCommands := """
                            |import com.github.tototoshi.csv._

--- a/src/test/scala/com/github/tototoshi/csv/CsvBenchmark.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CsvBenchmark.scala
@@ -1,0 +1,61 @@
+package com.github.tototoshi.csv
+
+import org.scalameter.api._
+import org.scalameter.picklers.Pickler
+
+
+object CsvBenchmark extends Bench.LocalTime {
+
+  val row = Seq("a", "1", "\"hey\"", "world")
+  private[this] val sizes = Gen.exponential("size")(10000, 100000, 10)
+  private[this] val quotings = {
+    val quotings = Seq(QUOTE_ALL, QUOTE_MINIMAL, QUOTE_NONE, QUOTE_NONNUMERIC)
+
+    implicit val pickler = new Pickler[Product with Serializable with Quoting] {
+      override def pickle(x: Product with Serializable with Quoting): Array[Byte] = {
+        x match {
+          case QUOTE_ALL => Array[Byte](0)
+          case QUOTE_MINIMAL => Array[Byte](1)
+          case QUOTE_NONE => Array[Byte](2)
+          case QUOTE_NONNUMERIC => Array[Byte](3)
+        }
+      }
+
+      override def unpickle(a: Array[Byte], from: Int): (Product with Serializable with Quoting, Int) = {
+        val quoting = a(0) match {
+          case 0 => QUOTE_ALL
+          case 1 => QUOTE_MINIMAL
+          case 2 => QUOTE_NONE
+          case 3 => QUOTE_NONNUMERIC
+        }
+
+        (quoting, from)
+      }
+    }
+
+    Gen.enumeration("quoting")(quotings: _*)
+  }
+
+  private case class QuotingCsvFormat(override val quoting: Quoting) extends DefaultCSVFormat
+
+  performance of "CSV" in {
+
+    measure method "write" in {
+      using(Gen.crossProduct(quotings, sizes)) in {
+        kvp =>
+          implicit val format = QuotingCsvFormat(kvp._1)
+          val size = kvp._2
+
+          var i = 0
+          val writer = CSVWriter.open(NullOutputStream)
+          while (i < size) {
+            writer.writeRow(row)
+            i += 1
+          }
+          writer.close()
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/com/github/tototoshi/csv/NullOutputStream.scala
+++ b/src/test/scala/com/github/tototoshi/csv/NullOutputStream.scala
@@ -1,0 +1,12 @@
+package com.github.tototoshi.csv
+
+import java.io.OutputStream
+
+/**
+  * An [[OutputStream]] that writes to nowhere
+  */
+case object NullOutputStream extends OutputStream {
+  override def write(b: Int): Unit = {
+
+  }
+}


### PR DESCRIPTION
I've added CSV Writer benchmarks to your request in #75 

Going to rebase it over this one to see the differences.

This is the results in master branch : 

```
cores: 4
hostname: shani-laptop
name: Java HotSpot(TM) 64-Bit Server VM
osArch: amd64
osName: Linux
vendor: Oracle Corporation
version: 25.92-b14
Parameters(quoting -> QUOTE_ALL, size -> 10000): 26.40353
Parameters(quoting -> QUOTE_ALL, size -> 100000): 273.820936
Parameters(quoting -> QUOTE_MINIMAL, size -> 10000): 30.928586
Parameters(quoting -> QUOTE_MINIMAL, size -> 100000): 314.662758
Parameters(quoting -> QUOTE_NONE, size -> 10000): 15.015368
Parameters(quoting -> QUOTE_NONE, size -> 100000): 152.473534
Parameters(quoting -> QUOTE_NONNUMERIC, size -> 10000): 24.142457
Parameters(quoting -> QUOTE_NONNUMERIC, size -> 100000): 247.681169
```