### PR TITLE
Make CSVFormat and CVSParser serializable

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVFormat.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVFormat.scala
@@ -15,7 +15,7 @@
 */
 package com.github.tototoshi.csv
 
-trait CSVFormat {
+trait CSVFormat extends Serializable {
 
   val delimiter: Char
 

--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -299,7 +299,7 @@ object CSVParser {
   }
 }
 
-class CSVParser(format: CSVFormat) {
+class CSVParser(format: CSVFormat) extends Serializable {
 
   def parseLine(input: String): Option[List[String]] = {
     val parsedResult = CSVParser.parse(input, format.escapeChar, format.delimiter, format.quoteChar)


### PR DESCRIPTION
In order to use the CSVParser with Apache Beam it would be beneficial if the according classes would be serializable. The patch works with Apache Beam. It would be brilliant if you could make a release soon, or we would have to fork the project. Thanks.