### PR TITLE
Substitute hardcoded string encoding with Java Charset constants

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -132,10 +132,21 @@ object CSVReader {
     }
   }
 
+  def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader = {
+    val fin = new FileInputStream(file)
+    try {
+      open(new InputStreamReader(fin, encoding))(format)
+    } catch {
+      case e: UnsupportedEncodingException => fin.close(); throw e
+    }
+  }
+
   def open(filename: String)(implicit format: CSVFormat): CSVReader =
     open(new File(filename), this.DEFAULT_ENCODING)(format)
 
   def open(filename: String, encoding: Charset)(implicit format: CSVFormat): CSVReader =
     open(new File(filename), encoding)(format)
 
+  def open(filename: String, encoding: String)(implicit format: CSVFormat): CSVReader =
+    open(new File(filename), encoding)(format)
 }

--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -18,8 +18,8 @@ package com.github.tototoshi.csv
 
 import java.io._
 import java.util.NoSuchElementException
-
 import scala.io.Source
+import java.nio.charset.{ StandardCharsets, Charset }
 
 class CSVReader protected (private val lineReader: LineReader)(implicit format: CSVFormat) extends Closeable {
 
@@ -113,7 +113,7 @@ class CSVReader protected (private val lineReader: LineReader)(implicit format: 
 
 object CSVReader {
 
-  val DEFAULT_ENCODING = "UTF-8"
+  val DEFAULT_ENCODING = StandardCharsets.UTF_8
 
   def open(source: Source)(implicit format: CSVFormat): CSVReader = new CSVReader(new SourceLineReader(source))(format)
 
@@ -123,7 +123,7 @@ object CSVReader {
     open(file, this.DEFAULT_ENCODING)(format)
   }
 
-  def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader = {
+  def open(file: File, encoding: Charset)(implicit format: CSVFormat): CSVReader = {
     val fin = new FileInputStream(file)
     try {
       open(new InputStreamReader(fin, encoding))(format)
@@ -135,7 +135,7 @@ object CSVReader {
   def open(filename: String)(implicit format: CSVFormat): CSVReader =
     open(new File(filename), this.DEFAULT_ENCODING)(format)
 
-  def open(filename: String, encoding: String)(implicit format: CSVFormat): CSVReader =
+  def open(filename: String, encoding: Charset)(implicit format: CSVFormat): CSVReader =
     open(new File(filename), encoding)(format)
 
 }

--- a/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVReader.scala
@@ -132,14 +132,8 @@ object CSVReader {
     }
   }
 
-  def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader = {
-    val fin = new FileInputStream(file)
-    try {
-      open(new InputStreamReader(fin, encoding))(format)
-    } catch {
-      case e: UnsupportedEncodingException => fin.close(); throw e
-    }
-  }
+  def open(file: File, encoding: String)(implicit format: CSVFormat): CSVReader =
+    open(file, Charset.forName(encoding))
 
   def open(filename: String)(implicit format: CSVFormat): CSVReader =
     open(new File(filename), this.DEFAULT_ENCODING)(format)

--- a/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
@@ -17,6 +17,7 @@
 package com.github.tototoshi.csv
 
 import java.io._
+import java.nio.charset.{ StandardCharsets, Charset }
 
 class CSVWriter(protected val writer: Writer)(implicit val format: CSVFormat) extends Closeable with Flushable {
 
@@ -117,29 +118,29 @@ class CSVWriter(protected val writer: Writer)(implicit val format: CSVFormat) ex
 
 object CSVWriter {
 
-  def open(file: File)(implicit format: CSVFormat): CSVWriter = open(file, false, "UTF-8")(format)
+  def open(file: File)(implicit format: CSVFormat): CSVWriter = open(file, false, StandardCharsets.UTF_8)(format)
 
-  def open(file: File, encoding: String)(implicit format: CSVFormat): CSVWriter = open(file, false, encoding)(format)
+  def open(file: File, encoding: Charset)(implicit format: CSVFormat): CSVWriter = open(file, false, encoding)(format)
 
-  def open(file: File, append: Boolean)(implicit format: CSVFormat): CSVWriter = open(file, append, "UTF-8")(format)
+  def open(file: File, append: Boolean)(implicit format: CSVFormat): CSVWriter = open(file, append, StandardCharsets.UTF_8)(format)
 
-  def open(fos: OutputStream)(implicit format: CSVFormat): CSVWriter = open(fos, "UTF-8")(format)
+  def open(fos: OutputStream)(implicit format: CSVFormat): CSVWriter = open(fos, StandardCharsets.UTF_8)(format)
 
-  def open(file: String)(implicit format: CSVFormat): CSVWriter = open(file, false, "UTF-8")(format)
+  def open(file: String)(implicit format: CSVFormat): CSVWriter = open(file, false, StandardCharsets.UTF_8)(format)
 
-  def open(file: String, encoding: String)(implicit format: CSVFormat): CSVWriter = open(file, false, encoding)(format)
+  def open(file: String, encoding: Charset)(implicit format: CSVFormat): CSVWriter = open(file, false, encoding)(format)
 
-  def open(file: String, append: Boolean)(implicit format: CSVFormat): CSVWriter = open(file, append, "UTF-8")(format)
+  def open(file: String, append: Boolean)(implicit format: CSVFormat): CSVWriter = open(file, append, StandardCharsets.UTF_8)(format)
 
-  def open(file: String, append: Boolean, encoding: String)(implicit format: CSVFormat): CSVWriter =
+  def open(file: String, append: Boolean, encoding: Charset)(implicit format: CSVFormat): CSVWriter =
     open(new File(file), append, encoding)(format)
 
-  def open(file: File, append: Boolean, encoding: String)(implicit format: CSVFormat): CSVWriter = {
+  def open(file: File, append: Boolean, encoding: Charset)(implicit format: CSVFormat): CSVWriter = {
     val fos = new FileOutputStream(file, append)
     open(fos, encoding)(format)
   }
 
-  def open(fos: OutputStream, encoding: String)(implicit format: CSVFormat): CSVWriter = {
+  def open(fos: OutputStream, encoding: Charset)(implicit format: CSVFormat): CSVWriter = {
     try {
       val writer = new OutputStreamWriter(fos, encoding)
       open(writer)(format)

--- a/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
@@ -120,6 +120,8 @@ object CSVWriter {
 
   def open(file: File)(implicit format: CSVFormat): CSVWriter = open(file, false, StandardCharsets.UTF_8)(format)
 
+  def open(file: File, encoding: String)(implicit format: CSVFormat): CSVWriter = open(file, false, Charset.forName(encoding))(format)
+
   def open(file: File, encoding: Charset)(implicit format: CSVFormat): CSVWriter = open(file, false, encoding)(format)
 
   def open(file: File, append: Boolean)(implicit format: CSVFormat): CSVWriter = open(file, append, StandardCharsets.UTF_8)(format)

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -51,6 +51,15 @@ class CSVReaderSpec extends FunSpec with Matchers with Using {
       }
     }
 
+    it("should throws UnsupportedEncodingException when unsupprted encoding is specified") {
+      intercept[UnsupportedEncodingException] {
+        using(CSVReader.open("src/test/resources/hash-separated-dollar-quote.csv", "unknown")) { reader =>
+          val map = reader.allWithHeaders()
+          map(0)("Foo ") should be("a")
+        }
+      }
+    }
+
     it("should be able to read an empty line") {
       using(CSVReader.open("src/test/resources/has-empty-line.csv", StandardCharsets.UTF_8)) { reader =>
         val lines = reader.all()

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -51,15 +51,6 @@ class CSVReaderSpec extends FunSpec with Matchers with Using {
       }
     }
 
-    it("should throws UnsupportedEncodingException when unsupprted encoding is specified") {
-      intercept[UnsupportedEncodingException] {
-        using(CSVReader.open("src/test/resources/hash-separated-dollar-quote.csv", "unknown")) { reader =>
-          val map = reader.allWithHeaders()
-          map(0)("Foo ") should be("a")
-        }
-      }
-    }
-
     it("should be able to read an empty line") {
       using(CSVReader.open("src/test/resources/has-empty-line.csv", StandardCharsets.UTF_8)) { reader =>
         val lines = reader.all()

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -1,8 +1,8 @@
 package com.github.tototoshi.csv
 
 import java.io.{ UnsupportedEncodingException, FileReader, File, StringReader }
-
 import org.scalatest._
+import java.nio.charset.{ StandardCharsets, Charset }
 
 class CSVReaderSpec extends FunSpec with Matchers with Using {
 
@@ -45,23 +45,14 @@ class CSVReaderSpec extends FunSpec with Matchers with Using {
         }
       }
 
-      using(CSVReader.open("src/test/resources/hash-separated-dollar-quote.csv", "utf-8")(format)) { reader =>
+      using(CSVReader.open("src/test/resources/hash-separated-dollar-quote.csv", StandardCharsets.UTF_8)(format)) { reader =>
         val map = reader.allWithHeaders()
         map(0)("Foo ") should be("a")
       }
     }
 
-    it("should throws UnsupportedEncodingException when unsupprted encoding is specified") {
-      intercept[UnsupportedEncodingException] {
-        using(CSVReader.open("src/test/resources/hash-separated-dollar-quote.csv", "unknown")) { reader =>
-          val map = reader.allWithHeaders()
-          map(0)("Foo ") should be("a")
-        }
-      }
-    }
-
     it("should be able to read an empty line") {
-      using(CSVReader.open("src/test/resources/has-empty-line.csv", "utf-8")) { reader =>
+      using(CSVReader.open("src/test/resources/has-empty-line.csv", StandardCharsets.UTF_8)) { reader =>
         val lines = reader.all()
         lines(1) should be(List(""))
       }
@@ -69,7 +60,7 @@ class CSVReaderSpec extends FunSpec with Matchers with Using {
       val format = new DefaultCSVFormat {
         override val treatEmptyLineAsNil = true
       }
-      using(CSVReader.open("src/test/resources/has-empty-line.csv", "utf-8")(format)) { reader =>
+      using(CSVReader.open("src/test/resources/has-empty-line.csv", StandardCharsets.UTF_8)(format)) { reader =>
         val lines = reader.all()
         lines(1) should be(Nil)
       }

--- a/src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala
@@ -1,8 +1,8 @@
 package com.github.tototoshi.csv
 
-import java.io.{ FileOutputStream, UnsupportedEncodingException, FileWriter, File }
-
+import java.io.{ FileOutputStream, FileWriter, File }
 import org.scalatest._
+import java.nio.charset.{ StandardCharsets, Charset }
 
 class CSVWriterSpec extends FunSpec with Matchers with BeforeAndAfter with Using {
 
@@ -27,7 +27,7 @@ class CSVWriterSpec extends FunSpec with Matchers with BeforeAndAfter with Using
       }
 
       it("should be constructed with OutputStream and encoding") {
-        using(CSVWriter.open(new FileOutputStream("test.csv"), "UTF-8")) { writer =>
+        using(CSVWriter.open(new FileOutputStream("test.csv"), StandardCharsets.UTF_8)) { writer =>
           writer.writeAll(List(List("a", "b", "c"), List("d", "e", "f")))
         }
       }
@@ -45,34 +45,26 @@ class CSVWriterSpec extends FunSpec with Matchers with BeforeAndAfter with Using
       }
 
       it("should be constructed with filename string and encoding") {
-        using(CSVWriter.open("test.csv", "utf-8")) { writer =>
+        using(CSVWriter.open("test.csv", StandardCharsets.UTF_8)) { writer =>
           writer.writeAll(List(List("a", "b", "c"), List("d", "e", "f")))
         }
       }
 
       it("should be constructed with filename string, append flag and encoding") {
-        using(CSVWriter.open("test.csv", false, "utf-8")) { writer =>
+        using(CSVWriter.open("test.csv", false, StandardCharsets.UTF_8)) { writer =>
           writer.writeAll(List(List("a", "b", "c"), List("d", "e", "f")))
         }
       }
 
       it("should be constructed with file and encoding") {
-        using(CSVWriter.open(new File("test.csv"), "utf-8")) { writer =>
+        using(CSVWriter.open(new File("test.csv"), StandardCharsets.UTF_8)) { writer =>
           writer.writeAll(List(List("a", "b", "c"), List("d", "e", "f")))
         }
       }
 
       it("should be constructed with file, append flag and encoding") {
-        using(CSVWriter.open(new File("test.csv"), false, "utf-8")) { writer =>
+        using(CSVWriter.open(new File("test.csv"), false, StandardCharsets.UTF_8)) { writer =>
           writer.writeAll(List(List("a", "b", "c"), List("d", "e", "f")))
-        }
-      }
-
-      it("should throws UnsupportedEncodingException when unsupprted encoding is specified") {
-        intercept[UnsupportedEncodingException] {
-          using(CSVWriter.open(new File("test.csv"), false, "unknown")) { writer =>
-            writer.writeAll(List(List("a", "b", "c"), List("d", "e", "f")))
-          }
         }
       }
 


### PR DESCRIPTION
This change will make the code safer from unsupported encoding errors due to
programmer mistakes.