### PR TITLE
CSVParserQuoteNone.parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "scala-csv"
 
 version := "1.3.6"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.0"
 
 crossScalaVersions := Seq("2.12.8", "2.11.12", "2.10.7", "2.13.0")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.sys.process._
 
 name := "scala-csv"
 
-version := "1.3.6"
+version := "1.3.6-RC1"
 
 scalaVersion := "2.12.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.sys.process._
 
 name := "scala-csv"
 
-version := "1.3.6-RC1"
+version := "1.3.6-SNAPSHOT"
 
 scalaVersion := "2.12.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "scala-csv"
 
 version := "1.3.6"
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.12.8"
 
 crossScalaVersions := Seq("2.12.8", "2.11.12", "2.10.7", "2.13.0")
 

--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -297,10 +297,165 @@ object CSVParser {
   }
 }
 
+object CSVParserQuoteNone {
+
+  private type State = Int
+  private final val Start = 0
+  private final val Field = 1
+  private final val Delimiter = 2
+  private final val End = 3
+
+  /**
+   * {{{
+   * scala> com.github.tototoshi.csv.CSVParserQuoteNone.parse("a,b,c", ',')
+   * res0: Option[List[String]] = Some(List(a, b, c))
+   *
+   * scala> com.github.tototoshi.csv.CSVParserQuoteNone.parse("\"a\",\"b\",\"c\"", ',')
+   * res1: Option[List[String]] = Some(List("a", "b", "c"))
+   *
+   * scala> com.github.tototoshi.csv.CSVParserQuoteNone.parse("a,b\"b\",c", ',')
+   * res2: Option[List[String]] = Some(List(a, b"b", c))
+   * }}}
+   */
+  def parse(input: String, delimiter: Char): Option[List[String]] = {
+    val buf: Array[Char] = input.toCharArray
+    var fields: Vector[String] = Vector()
+    var field = new StringBuilder
+    var state: State = Start
+    var pos = 0
+    val buflen = buf.length
+
+    if (buf.length > 0 && buf(0) == '\uFEFF') {
+      pos += 1
+    }
+
+    while (state != End && pos < buflen) {
+      val c = buf(pos)
+      (state: @switch) match {
+        case Start => {
+          c match {
+            case `delimiter` => {
+              fields :+= field.toString
+              field = new StringBuilder
+              state = Delimiter
+              pos += 1
+            }
+            case '\n' | '\u2028' | '\u2029' | '\u0085' => {
+              fields :+= field.toString
+              field = new StringBuilder
+              state = End
+              pos += 1
+            }
+            case '\r' => {
+              if (pos + 1 < buflen && buf(1) == '\n') {
+                pos += 1
+              }
+              fields :+= field.toString
+              field = new StringBuilder
+              state = End
+              pos += 1
+            }
+            case x => {
+              field += x
+              state = Field
+              pos += 1
+            }
+          }
+        }
+        case Delimiter => {
+          c match {
+            case `delimiter` => {
+              fields :+= field.toString
+              field = new StringBuilder
+              state = Delimiter
+              pos += 1
+            }
+            case '\n' | '\u2028' | '\u2029' | '\u0085' => {
+              fields :+= field.toString
+              field = new StringBuilder
+              state = End
+              pos += 1
+            }
+            case '\r' => {
+              if (pos + 1 < buflen && buf(1) == '\n') {
+                pos += 1
+              }
+              fields :+= field.toString
+              field = new StringBuilder
+              state = End
+              pos += 1
+            }
+            case x => {
+              field += x
+              state = Field
+              pos += 1
+            }
+          }
+        }
+        case Field => {
+          c match {
+            case `delimiter` => {
+              fields :+= field.toString
+              field = new StringBuilder
+              state = Delimiter
+              pos += 1
+            }
+            case '\n' | '\u2028' | '\u2029' | '\u0085' => {
+              fields :+= field.toString
+              field = new StringBuilder
+              state = End
+              pos += 1
+            }
+            case '\r' => {
+              if (pos + 1 < buflen && buf(1) == '\n') {
+                pos += 1
+              }
+              fields :+= field.toString
+              field = new StringBuilder
+              state = End
+              pos += 1
+            }
+            case x => {
+              field += x
+              state = Field
+              pos += 1
+            }
+          }
+        }
+        case End => {
+          sys.error("unexpected error")
+        }
+      }
+    }
+    (state: @switch) match {
+      case Delimiter => {
+        fields :+= ""
+        Some(fields.toList)
+      }
+      case _ => {
+        // When no crlf at end of file
+        state match {
+          case Field => {
+            fields :+= field.toString
+          }
+          case _ => {
+          }
+        }
+        Some(fields.toList)
+      }
+    }
+  }
+}
+
 class CSVParser(format: CSVFormat) extends Serializable {
 
   def parseLine(input: String): Option[List[String]] = {
-    val parsedResult = CSVParser.parse(input, format.escapeChar, format.delimiter, format.quoteChar)
+
+    val parsedResult = if (format.quoting == QUOTE_NONE) {
+      CSVParserQuoteNone.parse(input, format.delimiter)
+    } else {
+      CSVParser.parse(input, format.escapeChar, format.delimiter, format.quoteChar)
+    }
     if (parsedResult == Some(List("")) && format.treatEmptyLineAsNil) Some(Nil)
     else parsedResult
   }


### PR DESCRIPTION
Instead of change `CSVParser.parse` to handle `QUOTE_NONE`,
I simply deleted all quote related branches and states in `CSVParser.parse` and get `CSVParserQuoteNone.parse`.
Ihis will make `CSVParserQuoteNone.parse` faster.