### PR TITLE
Fix escaped chars in unquoted content

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -98,6 +98,10 @@ object CSVParser {
                 field += buf(pos + 1)
                 state = Field
                 pos += 2
+              } else if (pos + 1 < buflen) {
+                field += '\\'
+                state = Field
+                pos += 1
               } else {
                 throw new MalformedCSVException(buf.mkString)
               }

--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -140,7 +140,9 @@ object CSVParser {
                   state = Field
                   pos += 2
                 } else {
-                  throw new MalformedCSVException(buf.mkString)
+                  field += '\\'
+                  state = Field
+                  pos += 1
                 }
               } else {
                 state = QuoteEnd

--- a/src/test/resources/backslash-content.csv
+++ b/src/test/resources/backslash-content.csv
@@ -1,1 +1,2 @@
 "field1","field2","field3 says, \o/"
+"field1","field2",field3 says: \o/

--- a/src/test/resources/backslash-content.csv
+++ b/src/test/resources/backslash-content.csv
@@ -1,2 +1,3 @@
 "field1","field2","field3 says, \o/"
 "field1","field2",field3 says: \o/
+"field1","field2",\N

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -149,6 +149,7 @@ class CSVReaderSpec extends AnyFunSpec with Matchers with Using {
       }
       res(0) should be(List("field1", "field2", raw"field3 says, \o/"))
       res(1) should be(List("field1", "field2", raw"field3 says: \o/"))
+      res(2) should be(List("field1", "field2", raw"\N"))
     }
 
     it("read simple CSV file with empty quoted fields") {

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -138,16 +138,17 @@ class CSVReaderSpec extends AnyFunSpec with Matchers with Using {
     }
 
     it("should read csv file whose escape char is in the content without escaping a char") {
-      var res: List[String] = Nil
+      var res: List[Seq[String]] = Nil
       implicit val format = new DefaultCSVFormat {
         override val escapeChar: Char = '\\'
       }
-      using(CSVReader.open("src/test/resources/backslash-content.csv")(format)) { reader =>
-        reader foreach { fields =>
-          res = res ++ fields
+      using(CSVReader.open(new FileReader("src/test/resources/backslash-content.csv"))(format)) { reader =>
+        reader.foreach { fields =>
+          res = res ::: fields :: Nil
         }
       }
-      res should be(List("field1", "field2", raw"field3 says, \o/"))
+      res(0) should be(List("field1", "field2", raw"field3 says, \o/"))
+      res(1) should be(List("field1", "field2", raw"field3 says: \o/"))
     }
 
     it("read simple CSV file with empty quoted fields") {


### PR DESCRIPTION
Similar to https://github.com/tototoshi/scala-csv/pull/153/files but for unquoted content. 

I don't believe there is any reason to not allow escape chars in this context. This allows the parsing of postgres CSV files, for example: https://www.postgresql.org/docs/9.2/sql-copy.html 