### PR TITLE
Fix #86

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -136,23 +136,6 @@ object CSVParser {
         }
         case Field => {
           c match {
-            case `escapeChar` => {
-              if (pos + 1 < buflen) {
-                if (buf(pos + 1) == escapeChar
-                  || buf(pos + 1) == delimiter) {
-                  field += buf(pos + 1)
-                  state = Field
-                  pos += 2
-                } else {
-                  field += '\\'
-                  state = Field
-                  pos += 1
-                }
-              } else {
-                state = QuoteEnd
-                pos += 1
-              }
-            }
             case `delimiter` => {
               fields :+= field.toString
               field = new StringBuilder

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -246,6 +246,15 @@ class CSVReaderSpec extends AnyFunSpec with Matchers with Using {
       }
     }
 
+    it("parses an unquoted line with quotes in it") {
+      val r = new StringReader(
+        """a,b,c
+          |a,"b",c
+          |a,a"b"c,c
+          |""".stripMargin)
+      CSVReader.open(r)(new DefaultCSVFormat {}).all()(2)(1).equals("""a"b"c""")
+    }
+
     describe("iterator fetched from #iterator") {
 
       it("has #hasNext") {


### PR DESCRIPTION
When inside "Field" (and not "QuotedField") there are no escape characters. This commit fixes #86.