### PR TITLE
Malformed csv detection bug

### DIFF
--- a/src/test/resources/malformed.csv
+++ b/src/test/resources/malformed.csv
@@ -1,1 +1,1 @@
-this,is,malformed,"csv,data
+this,is,malformed,c"sv,data


### PR DESCRIPTION
I think a bug was introduced in > v1.3.8 where malformed csv's with a dangling quotation mark `"` is only detected when its after a `,`. This was not the case in v1.3.8 or below. 

I am opening a PR to showcase this bug with a failed test case. The below change fails the testcase `it("should be throw exception against malformed input")` in file [CSVReadSpec.scala ](https://github.com/tototoshi/scala-csv/blob/master/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala#L188-L194)

Failed test output:

```
Expected exception com.github.tototoshi.csv.MalformedCSVException to be thrown, but no exception was thrown
ScalaTestFailureLocation: com.github.tototoshi.csv.CSVReaderSpec at (CSVReaderSpec.scala:189)
org.scalatest.exceptions.TestFailedException: Expected exception com.github.tototoshi.csv.MalformedCSVException to be thrown, but no exception was thrown
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
	at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
	at org.scalatest.funspec.AnyFunSpec.newAssertionFailedException(AnyFunSpec.scala:1631)
	at org.scalatest.Assertions.intercept(Assertions.scala:766)
	at org.scalatest.Assertions.intercept$(Assertions.scala:746)
	at org.scalatest.funspec.AnyFunSpec.intercept(AnyFunSpec.scala:1631)
	at com.github.tototoshi.csv.CSVReaderSpec.$anonfun$new$46(CSVReaderSpec.scala:189)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.funspec.AnyFunSpecLike$$anon$1.apply(AnyFunSpecLike.scala:517)
	at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
	at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
	at org.scalatest.funspec.AnyFunSpec.withFixture(AnyFunSpec.scala:1631)
	at org.scalatest.funspec.AnyFunSpecLike.invokeWithFixture$1(AnyFunSpecLike.scala:515)
	at org.scalatest.funspec.AnyFunSpecLike.$anonfun$runTest$1(AnyFunSpecLike.scala:527)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.funspec.AnyFunSpecLike.runTest(AnyFunSpecLike.scala:527)
	at org.scalatest.funspec.AnyFunSpecLike.runTest$(AnyFunSpecLike.scala:509)
	at org.scalatest.funspec.AnyFunSpec.runTest(AnyFunSpec.scala:1631)
	at org.scalatest.funspec.AnyFunSpecLike.$anonfun$runTests$1(AnyFunSpecLike.scala:560)
	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:390)
	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:427)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
	at org.scalatest.funspec.AnyFunSpecLike.runTests(AnyFunSpecLike.scala:560)
	at org.scalatest.funspec.AnyFunSpecLike.runTests$(AnyFunSpecLike.scala:559)
	at org.scalatest.funspec.AnyFunSpec.runTests(AnyFunSpec.scala:1631)
	at org.scalatest.Suite.run(Suite.scala:1112)
	at org.scalatest.Suite.run$(Suite.scala:1094)
	at org.scalatest.funspec.AnyFunSpec.org$scalatest$funspec$AnyFunSpecLike$$super$run(AnyFunSpec.scala:1631)
	at org.scalatest.funspec.AnyFunSpecLike.$anonfun$run$1(AnyFunSpecLike.scala:564)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
	at org.scalatest.funspec.AnyFunSpecLike.run(AnyFunSpecLike.scala:564)
	at org.scalatest.funspec.AnyFunSpecLike.run$(AnyFunSpecLike.scala:563)
	at org.scalatest.funspec.AnyFunSpec.run(AnyFunSpec.scala:1631)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:45)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1322)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1316)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1316)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:993)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:971)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1482)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:971)
	at org.scalatest.tools.Runner$.run(Runner.scala:798)
	at org.scalatest.tools.Runner.run(Runner.scala)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.runScalaTest2or3(ScalaTestRunner.java:38)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.main(ScalaTestRunner.java:25)
```

If someone can help with fixing this bug it would be greatly appreciated 🙇 