### PR TITLE
Add scala native platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,139 +2,137 @@ import scala.sys.process._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-name := "scala-csv"
+ThisBuild / version := "2.0.0"
 
-version := "2.0.0"
+ThisBuild / scalaVersion := "2.13.15"
 
-scalaVersion := "2.13.15"
+lazy val scalaCsv = project.in(file(".")).settings(
+  name := "scala-csv",
 
-crossScalaVersions := Seq("2.12.20", "2.11.12", "2.10.7", "2.13.15", "3.3.4")
+  crossScalaVersions := Seq("2.12.20", "2.11.12", "2.10.7", "2.13.15", "3.3.4"),
 
-TaskKey[Unit]("checkScalariform") := {
-  val diff = "git diff".!!
-  if(diff.nonEmpty){
-    sys.error("Working directory is dirty!\n" + diff)
-  }
-}
+  TaskKey[Unit]("checkScalariform") := {
+    val diff = "git diff".!!
+    if(diff.nonEmpty){
+      sys.error("Working directory is dirty!\n" + diff)
+    }
+  },
 
-organization := "com.github.tototoshi"
+  organization := "com.github.tototoshi",
 
-libraryDependencies ++= {
-  Seq(
+  libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest-funspec" % "3.2.19" % Test,
     "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.19" % Test,
     if (scalaVersion.value.startsWith("2.")) "org.scalacheck" %% "scalacheck" % "1.14.3" % Test
     else "org.scalacheck" %% "scalacheck" % "1.18.1" % Test
-  )
-}
+  ),
 
-val enableScalameter = settingKey[Boolean]("")
+  libraryDependencies ++= {
+    if (enableScalameter.value) {
+      Seq("com.storm-enroute" %% "scalameter" % "0.19" % Test)
+    } else {
+      Nil
+    }
+  },
 
-enableScalameter := {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, v)) =>
-      11 <= v && v <= 13
-    case _ =>
-      false
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-feature",
+    "-language:implicitConversions"
+  ),
+
+  scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
+    case Some((2, v)) if v >= 11 => Seq("-Ywarn-unused")
+  }.toList.flatten,
+
+  scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
+    case Some((2, 11 | 12)) =>
+      Seq("-Xsource:3")
+    case Some((2, 13)) =>
+      Seq("-Xsource:3-cross")
+  }.toList.flatten,
+
+  Test / sources := {
+    val s = (Test / sources).value
+    val exclude = Set("CsvBenchmark.scala")
+    if (enableScalameter.value) {
+      s
+    } else {
+      s.filterNot(f => exclude(f.getName))
+    }
+  },
+
+  testFrameworks ++= {
+    if (enableScalameter.value) {
+      Seq(new TestFramework("org.scalameter.ScalaMeterFramework"))
+    } else Nil
+  },
+
+  Test / parallelExecution := false,
+
+  logBuffered := false,
+
+  compile / javacOptions += "-Xlint",
+
+  compile / javacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) if v <= 11 =>
+        Seq("-target", "6", "-source", "6")
+      case _ =>
+        Seq("-target", "8", "-source", "8")
+    }
+  },
+
+  initialCommands := """
+                       |import com.github.tototoshi.csv._
+                     """.stripMargin,
+
+  publishMavenStyle := true,
+
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (version.value.trim.endsWith("SNAPSHOT"))
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    else
+      Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+  },
+
+  Test / publishArtifact := false,
+
+  pomExtra := <url>https://github.com/tototoshi/scala-csv</url>
+    <licenses>
+      <license>
+        <name>Apache License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+    <scm>
+      <url>git@github.com:tototoshi/scala-csv.git</url>
+      <connection>scm:git:git@github.com:tototoshi/scala-csv.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <id>tototoshi</id>
+        <name>Toshiyuki Takahashi</name>
+        <url>https://tototoshi.github.io</url>
+      </developer>
+    </developers>,
+
+  Compile / unmanagedSourceDirectories += {
+    val dir = CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) if v <= 12 =>
+        "scala-2.13-"
+      case _ =>
+        "scala-2.13+"
+    }
+    baseDirectory.value / "src" / "main" / dir
   }
-}
-
-libraryDependencies ++= {
-  if (enableScalameter.value) {
-    Seq("com.storm-enroute" %% "scalameter" % "0.19" % "test")
-  } else {
-    Nil
-  }
-}
-
-scalacOptions ++= Seq(
-  "-deprecation",
-  "-feature",
-  "-language:implicitConversions"
 )
 
-scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
-  case Some((2, v)) if v >= 11 => Seq("-Ywarn-unused")
-}.toList.flatten
-
-scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
-  case Some((2, 11 | 12)) =>
-    Seq("-Xsource:3")
-  case Some((2, 13)) =>
-    Seq("-Xsource:3-cross")
-}.toList.flatten
-
-Test / sources := {
-  val s = (Test / sources).value
-  val exclude = Set("CsvBenchmark.scala")
-  if (enableScalameter.value) {
-    s
-  } else {
-    s.filterNot(f => exclude(f.getName))
-  }
-}
-
-testFrameworks += new TestFramework(
-  "org.scalameter.ScalaMeterFramework"
+val enableScalameter = Def.setting(
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) => 11 <= v && v <= 13
+      case _ => false
+    }
 )
-
-Test / parallelExecution := false
-
-logBuffered := false
-
-compile / javacOptions += "-Xlint"
-
-compile / javacOptions ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, v)) if v <= 11 =>
-      Seq("-target", "6", "-source", "6")
-    case _ =>
-      Seq("-target", "8", "-source", "8")
-  }
-}
-
-initialCommands := """
-                     |import com.github.tototoshi.csv._
-                   """.stripMargin
-
-publishMavenStyle := true
-
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (version.value.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
-
-Test / publishArtifact := false
-
-pomExtra := <url>https://github.com/tototoshi/scala-csv</url>
-<licenses>
-  <license>
-    <name>Apache License, Version 2.0</name>
-    <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-    <distribution>repo</distribution>
-  </license>
-</licenses>
-<scm>
-  <url>git@github.com:tototoshi/scala-csv.git</url>
-  <connection>scm:git:git@github.com:tototoshi/scala-csv.git</connection>
-</scm>
-<developers>
-  <developer>
-    <id>tototoshi</id>
-    <name>Toshiyuki Takahashi</name>
-    <url>https://tototoshi.github.io</url>
-  </developer>
-</developers>
-
-Compile / unmanagedSourceDirectories += {
-  val dir = CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, v)) if v <= 12 =>
-      "scala-2.13-"
-    case _ =>
-      "scala-2.13+"
-  }
-  baseDirectory.value / "src" / "main" / dir
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,8 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.5.7")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+
 libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"

--- a/src/main/scala-readers/com/github/tototoshi/csv/LineReader.scala
+++ b/src/main/scala-readers/com/github/tototoshi/csv/LineReader.scala
@@ -1,0 +1,9 @@
+package com.github.tototoshi.csv
+
+import java.io.Closeable
+import java.io.IOException
+
+trait LineReader extends Closeable {
+  @throws[IOException]
+  def readLineWithTerminator(): String
+}

--- a/src/main/scala-readers/com/github/tototoshi/csv/ReaderLineReader.scala
+++ b/src/main/scala-readers/com/github/tototoshi/csv/ReaderLineReader.scala
@@ -1,0 +1,40 @@
+package com.github.tototoshi.csv
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.Reader
+
+class ReaderLineReader(baseReader: Reader) extends LineReader {
+  private val bufferedReader: BufferedReader = new BufferedReader(baseReader)
+
+  @throws[IOException]
+  def readLineWithTerminator(): String = {
+    val sb = new StringBuilder()
+    var c: Int = 0
+
+    while (c != -1) {
+      c = bufferedReader.read()
+      if (c != -1) sb.append(c.toChar)
+      if (c == '\n' || c == '\u2028' || c == '\u2029' || c == '\u0085') {
+        c = -1
+      }
+      if (c == '\r') {
+        bufferedReader.mark(1)
+        c = bufferedReader.read()
+        if (c == '\n') {
+          sb.append('\n')
+        } else {
+          bufferedReader.reset()
+        }
+        c = -1
+      }
+    }
+    if (sb.isEmpty) null else sb.toString()
+  }
+
+  @throws[IOException]
+  def close(): Unit = {
+    bufferedReader.close()
+    baseReader.close()
+  }
+}

--- a/src/main/scala-readers/com/github/tototoshi/csv/SourceLineReader.scala
+++ b/src/main/scala-readers/com/github/tototoshi/csv/SourceLineReader.scala
@@ -1,0 +1,40 @@
+package com.github.tototoshi.csv
+
+import java.io.IOException
+import scala.io.Source
+
+class SourceLineReader(source: Source) extends LineReader {
+
+  private var buffer: Int = -1
+
+  @throws[IOException]
+  def readLineWithTerminator(): String = {
+    val sb = new StringBuilder()
+    var c: Int = 0
+
+    while (c != -1) {
+      if (buffer != -1) {
+        c = buffer
+        buffer = -1
+      } else {
+        c = if (source.hasNext) source.next() else -1
+      }
+      if (c != -1) sb.append(c.toChar)
+      if (c == '\n' || c == '\u2028' || c == '\u2029' || c == '\u0085') {
+        c = -1
+      }
+      if (c == '\r') {
+        buffer = if (source.hasNext) source.next() else -1
+        if (buffer == '\n') {
+          sb.append('\n')
+          buffer = -1
+        }
+        c = -1
+      }
+    }
+    if (sb.isEmpty) null else sb.toString()
+  }
+
+  @throws[IOException]
+  override def close(): Unit = source.close()
+}

--- a/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVReaderSpec.scala
@@ -312,14 +312,14 @@ class CSVReaderSpec extends AnyFunSpec with Matchers with Using {
       describe("When the file is empty") {
         it("returns an empty list") {
           using(CSVReader.open(new FileReader("src/test/resources/empty.csv"))) { reader =>
-            reader.iteratorWithHeaders should be(Symbol("empty"))
+            reader.iteratorWithHeaders should be(empty)
           }
         }
       }
       describe("When the file has only one line") {
         it("returns an empty list") {
           using(CSVReader.open(new FileReader("src/test/resources/only-header.csv"))) { reader =>
-            reader.iteratorWithHeaders should be(Symbol("empty"))
+            reader.iteratorWithHeaders should be(empty)
           }
         }
       }
@@ -338,14 +338,14 @@ class CSVReaderSpec extends AnyFunSpec with Matchers with Using {
       describe("When the file is empty") {
         it("returns an empty list") {
           using(CSVReader.open(new FileReader("src/test/resources/empty.csv"))) { reader =>
-            reader.allWithHeaders() should be(Symbol("empty"))
+            reader.allWithHeaders() should be(empty)
           }
         }
       }
       describe("When the file has only one line") {
         it("returns an empty list") {
           using(CSVReader.open(new FileReader("src/test/resources/only-header.csv"))) { reader =>
-            reader.allWithHeaders() should be(Symbol("empty"))
+            reader.allWithHeaders() should be(empty)
           }
         }
       }


### PR DESCRIPTION
This PR implements `src/main/java` in Scala (as `src/main/scala-readers`) and adds a ScalaNative platform.

Currently, new sources are only connected to non-JVM builds, and there are no changes to the JVM platform at all.
JVM build uses exactly the same sources and compile settings as before, so maybe there's no need for a version bump, as there are no changes to ship compared to existing 2.0.0 artifacts.

As for the upcoming versions, it would be nice to drop `src/main/java` completely. Unfortunately, these interfaces are defined as public. Following semver conventions strictly, that might be considered as requiring a major version bump, but it seems very unlikely that library users extend existing LineReaders to implement their own.

If needed, I can separate this PR into parts, like:
 - preparing `build.sbt` to multi-projects (first commit)
 - implement LineReaders in scala
 - scala-native
 
please let me know if it would make sense.
