### PR TITLE
Preserve escape char in unquoted fields when not followed by a special char

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -99,7 +99,7 @@ object CSVParser {
                 state = Field
                 pos += 2
               } else if (pos + 1 < buflen) {
-                field += '\\'
+                field += escapeChar
                 state = Field
                 pos += 1
               } else {
@@ -144,7 +144,7 @@ object CSVParser {
                   state = Field
                   pos += 2
                 } else {
-                  field += '\\'
+                  field += escapeChar
                   state = Field
                   pos += 1
                 }

--- a/src/test/scala/com/github/tototoshi/csv/CSVParserSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVParserSpec.scala
@@ -1,0 +1,21 @@
+package com.github.tototoshi.csv
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class CSVParserSpec extends AnyFunSpec with Matchers {
+
+  describe("CSVParser.parse") {
+
+    describe("when the escape char appears in an unquoted field and is not followed by a special char") {
+
+      it("preserves the original escape char (default format)") {
+        CSVParser.parse("ab\"c,d", '"', ',', '"') should be(Some(List("ab\"c", "d")))
+      }
+
+      it("preserves the original escape char when escape char differs from quote char") {
+        CSVParser.parse(",|x", '|', ',', '"') should be(Some(List("", "|x")))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

When the parser encountered the escape character inside an unquoted field (or immediately after a delimiter) and the following character was not the escape character itself or the delimiter, the original character was replaced with a hardcoded `\\` literal. With the default `CSVFormat` (where `escapeChar == quoteChar == '\"'`), an input like `ab\"c,d` was parsed as `[\"ab\\c\", \"d\"]` instead of `[\"ab\\\"c\", \"d\"]` — the `\"` was silently rewritten to `\\`.

The fix replaces the hardcoded `'\\\\'` with the configured `escapeChar` at both occurrences in `CSVParser.parse` (the `Delimiter` state and the `Field` state).

## Changes
- `src/main/scala/com/github/tototoshi/csv/CSVParser.scala`: `field += '\\\\'` → `field += escapeChar` at the two affected branches.
- `src/test/scala/com/github/tototoshi/csv/CSVParserSpec.scala`: new spec with two regression tests covering both branches (default format, and escape-char different from quote-char).

## Test plan
- [x] New tests fail on `master` with the current parser
- [x] New tests pass with the fix applied
- [x] Full existing test suite still passes (`sbt test`, 68 tests)