### PR TITLE
Escape delimiter and escape char in fields when quoting is QUOTE_NONE

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVWriter.scala
@@ -80,13 +80,23 @@ class CSVWriter(protected val writer: Writer)(implicit val format: CSVFormat) ex
         var i = 0
         while (i < field.length) {
           val char = field(i)
-          if (char == format.quoteChar || (format.quoting == QUOTE_NONE && char == format.delimiter)) {
+          if (char == format.quoteChar) {
             printWriter.print(format.escapeChar)
           }
           printWriter.print(char)
           i += 1
         }
         printWriter.print(format.quoteChar)
+      } else if (format.quoting == QUOTE_NONE) {
+        var i = 0
+        while (i < field.length) {
+          val char = field(i)
+          if (char == format.delimiter || char == format.escapeChar) {
+            printWriter.print(format.escapeChar)
+          }
+          printWriter.print(char)
+          i += 1
+        }
       } else {
         printWriter.print(field)
       }

--- a/src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala
@@ -218,6 +218,32 @@ class CSVWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfter with Us
 
           readFileAsString("test.csv") should be(expected)
         }
+
+        it("should escape the delimiter when it appears in a field") {
+          object quoteNoneFormat extends DefaultCSVFormat {
+            override val quoting: Quoting = QUOTE_NONE
+            override val escapeChar: Char = '\\'
+          }
+
+          using(CSVWriter.open(new FileWriter("test.csv"))(quoteNoneFormat)) { writer =>
+            writer.writeRow(List("a,b", "c"))
+          }
+
+          readFileAsString("test.csv") should be("a\\,b,c\n")
+        }
+
+        it("should escape the escape char when it appears in a field") {
+          object quoteNoneFormat extends DefaultCSVFormat {
+            override val quoting: Quoting = QUOTE_NONE
+            override val escapeChar: Char = '\\'
+          }
+
+          using(CSVWriter.open(new FileWriter("test.csv"))(quoteNoneFormat)) { writer =>
+            writer.writeRow(List("a\\b", "c"))
+          }
+
+          readFileAsString("test.csv") should be("a\\\\b,c\n")
+        }
       }
       describe("When quoting is set to QUOTE_NONNUMERIC") {
         it("should quote only nonnumeric fields") {


### PR DESCRIPTION
## Summary

When a `CSVFormat` with `quoting = QUOTE_NONE` is used (the default for `TSVFormat`), `CSVWriter.writeRow` / `writeAll` emitted fields unchanged. A field that contained the delimiter or the escape char was written verbatim, producing output that cannot be parsed back correctly.

Inside `printField` there was already a branch that tried to prefix the delimiter with the escape char under `QUOTE_NONE`:

```scala
if (char == format.quoteChar || (format.quoting == QUOTE_NONE && char == format.delimiter)) {
  printWriter.print(format.escapeChar)
}
```

…but it lived inside `if (shouldQuote(field, format.quoting))`, and `shouldQuote` returns `false` unconditionally for `QUOTE_NONE`, so that branch was dead code.

This PR moves the special case to a dedicated `QUOTE_NONE` branch that walks the field and prefixes each occurrence of the delimiter or escape char with the escape char, so the round trip through `CSVParser` produces the original value.

## Changes
- `src/main/scala/com/github/tototoshi/csv/CSVWriter.scala`: add a `QUOTE_NONE` branch in `printField`; simplify the existing `shouldQuote` branch (which no longer has to check for `QUOTE_NONE`).
- `src/test/scala/com/github/tototoshi/csv/CSVWriterSpec.scala`: two regression tests for the `QUOTE_NONE` writer (delimiter inside a field, escape char inside a field).

## Scope / intentional non-goals
- `CR`/`LF` inside a field under `QUOTE_NONE` is still passed through, because the current `CSVParser` has no way to round-trip a `\\<newline>` escape (the parser would consume the escape char but then still break on the newline). Handling that case cleanly would mean throwing at write time, which is a larger behavior change; left for a follow-up.

## Test plan
- [x] New tests fail on `master` (writer emits unescaped delimiter / escape char)
- [x] New tests pass with the fix applied
- [x] Full existing test suite still passes (`sbt test`, 68 tests), including the existing `QUOTE_NONE` "should quote no field" case