### PR TITLE
Fix CRLF look-ahead to check buf(pos + 1) instead of buf(1)

### DIFF
--- a/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
+++ b/src/main/scala/com/github/tototoshi/csv/CSVParser.scala
@@ -71,7 +71,7 @@ object CSVParser {
               pos += 1
             }
             case '\r' => {
-              if (pos + 1 < buflen && buf(1) == '\n') {
+              if (pos + 1 < buflen && buf(pos + 1) == '\n') {
                 pos += 1
               }
               fields :+= field.toString
@@ -119,7 +119,7 @@ object CSVParser {
               pos += 1
             }
             case '\r' => {
-              if (pos + 1 < buflen && buf(1) == '\n') {
+              if (pos + 1 < buflen && buf(pos + 1) == '\n') {
                 pos += 1
               }
               fields :+= field.toString
@@ -166,7 +166,7 @@ object CSVParser {
               pos += 1
             }
             case '\r' => {
-              if (pos + 1 < buflen && buf(1) == '\n') {
+              if (pos + 1 < buflen && buf(pos + 1) == '\n') {
                 pos += 1
               }
               fields :+= field.toString
@@ -229,7 +229,7 @@ object CSVParser {
               pos += 1
             }
             case '\r' => {
-              if (pos + 1 < buflen && buf(1) == '\n') {
+              if (pos + 1 < buflen && buf(pos + 1) == '\n') {
                 pos += 1
               }
               fields :+= field.toString

--- a/src/test/scala/com/github/tototoshi/csv/CSVParserSpec.scala
+++ b/src/test/scala/com/github/tototoshi/csv/CSVParserSpec.scala
@@ -1,0 +1,29 @@
+package com.github.tototoshi.csv
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class CSVParserSpec extends AnyFunSpec with Matchers {
+
+  describe("CSVParser.parse") {
+
+    describe("CRLF handling in each state") {
+
+      it("handles CRLF in the Start state (empty line terminated by CRLF)") {
+        CSVParser.parse("\r\n", '\\', ',', '"') should be(Some(List("")))
+      }
+
+      it("handles CRLF in the Delimiter state (trailing empty field terminated by CRLF)") {
+        CSVParser.parse("a,\r\n", '\\', ',', '"') should be(Some(List("a", "")))
+      }
+
+      it("handles CRLF in the Field state (unquoted row terminated by CRLF)") {
+        CSVParser.parse("a,b,c\r\n", '\\', ',', '"') should be(Some(List("a", "b", "c")))
+      }
+
+      it("handles CRLF in the QuoteEnd state (row of quoted fields terminated by CRLF)") {
+        CSVParser.parse("\"a\",\"b\"\r\n", '\\', ',', '"') should be(Some(List("a", "b")))
+      }
+    }
+  }
+}


### PR DESCRIPTION
> Opened as a draft: the change does **not** affect observable parser output — see the \"Why this is a draft\" section below.

## Summary

`CSVParser.parse` walks the input with a position cursor `pos`. In every state that consumes a line terminator (`Start`, `Delimiter`, `Field`, `QuoteEnd`), the CRLF look-ahead was written as:

```scala
case '\r' => {
  if (pos + 1 < buflen && buf(1) == '\n') {
    pos += 1
  }
  ...
  state = End
  pos += 1
}
```

`buf(1)` is the second char of the whole input buffer, not the char immediately after the `\r`. The intent is clearly to peek at `buf(pos + 1)` so a `CRLF` pair is consumed together. This PR fixes all four occurrences.

## Changes

- `src/main/scala/com/github/tototoshi/csv/CSVParser.scala` — `buf(1)` → `buf(pos + 1)` in the `\r` branches of the `Start`, `Delimiter`, `Field`, and `QuoteEnd` states (lines 74, 122, 169, 232).
- `src/test/scala/com/github/tototoshi/csv/CSVParserSpec.scala` — new spec exercising `CSVParser.parse` with CRLF input for each of the four states.

## Why this is a draft

The typo has no observable effect today:

- The only branch that reads `buf(1)` sets `state = End` immediately afterwards.
- The outer loop condition is `while (state != End && pos < buflen)`, so the loop exits on the next iteration regardless of whether `pos` was advanced past the trailing `\n`.
- The final match on `state` only inspects `state`, not `pos` or the remaining buffer, so the extra unconsumed `\n` is never surfaced to the caller.

As a result, the added tests pass **both before and after** this change. They're included because direct users of the public `CSVParser.parse` object had no prior coverage for CRLF behavior, and because a future refactor that moves any work after the `\r` branch could turn this dormant typo into a real bug. I'm opening this as a draft so a maintainer can decide whether code-correctness-only cleanup is welcome before it gets marked ready.

## Test plan

- [x] `sbt test` — 70 tests pass (4 new, 66 pre-existing)
- [x] Verified manually that the 4 new tests also pass on `master` (bug is dormant)